### PR TITLE
Fix IMAP index size

### DIFF
--- a/MagicaVoxel-file-format-vox-extension.txt
+++ b/MagicaVoxel-file-format-vox-extension.txt
@@ -161,5 +161,5 @@ STRING	: color name
 size	: 256
 // for each index
 {
-int32	: palette index association
+int8	: palette index association
 }x256


### PR DESCRIPTION
Each index on an IMAP chunk is 1 byte in size.