### PR TITLE
Correct IMAP Format

### DIFF
--- a/MagicaVoxel-file-format-vox-extension.txt
+++ b/MagicaVoxel-file-format-vox-extension.txt
@@ -161,5 +161,5 @@ STRING	: color name
 size	: 256
 // for each index
 {
-int32	: palette index association
+int8	: palette index association
 }x256


### PR DESCRIPTION
IMAP uses a 1-byte palette index association data type and not 4-byte (int32).